### PR TITLE
Change reply to emit in conversation utils, closes #24

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,8 @@ module.exports = {
 
 				// Handle the expected response.
 				dialog.addChoice(regex, (msg) => {
+					msg.match[1] = that.stripBotName(robot.name, msg.match[1]);
+
 					// force dialog removal
 					dialog.resetChoices();
 					dialog.emit('timeout');

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,12 @@ module.exports = {
 
 				// Handle the expected response.
 				dialog.addChoice(regex, (msg) => {
-					msg.match[1] = that.stripBotName(robot.name, msg.match[1]);
+					if (msg.match[0]) {
+						msg.match[0] = that.stripBotName(robot.name, msg.match[0]);
+					}
+					if (msg.match[1]) {
+						msg.match[1] = that.stripBotName(robot.name, msg.match[1]);
+					}
 
 					// force dialog removal
 					dialog.resetChoices();

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,12 +79,13 @@ module.exports = {
 		return new Promise((resolve, reject) => {
 			function getResponse() {
 				// Present the user with a prompt for input.
-				res.reply(prompt);
+				robot.emit('ibmcloud.formatter', { response: res, message: prompt});
+
 
 				// Control the response when the timeout expires.
 				dialog.dialogTimeout = function(msg) {
 					/* istanbul ignore next */
-					res.reply(i18n.__('conversation.timed.out'));
+					robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('conversation.timed.out')});
 				};
 
 				// Handle the expected response.
@@ -107,7 +108,7 @@ module.exports = {
 						reject();
 					}
 					else {
-						res.reply(i18n.__('conversation.try.again.or.exit'));
+						robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('conversation.try.again.or.exit')});
 						getResponse();
 					}
 				});
@@ -119,17 +120,18 @@ module.exports = {
 	// -------------------------------------------------------
 	// Recurse until the expected match for yes/no is made.
 	// -------------------------------------------------------
-	getConfirmedResponse: function(res, switchBoard, prompt, negativeResponse) {
+	getConfirmedResponse: function(res, robot, switchBoard, prompt, negativeResponse) {
 		let that = this;
 		let dialog = switchBoard.startDialog(res);
 		return new Promise((resolve, reject) => {
 			function getResponse() {
 				// Present the user with a prompt for input.
-				res.reply(prompt);
+				robot.emit('ibmcloud.formatter', { response: res, message: prompt});
+
 				// Control the response when the timeout expires.
 				dialog.dialogTimeout = function(msg) {
 					/* istanbul ignore next */
-					res.reply(i18n.__('conversation.timed.out'));
+					robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('conversation.timed.out')});
 				};
 				// Handle a confirmation.
 				dialog.addChoice(that.CONFIRM, (msg) => {
@@ -140,7 +142,7 @@ module.exports = {
 				});
 				// Handle a rejection.
 				dialog.addChoice(that.DENY, (msg) => {
-					res.reply(negativeResponse);
+					robot.emit('ibmcloud.formatter', { response: res, message: negativeResponse});
 					// force dialog removal
 					dialog.resetChoices();
 					dialog.emit('timeout');
@@ -148,7 +150,7 @@ module.exports = {
 				});
 				// Handle an unexpected response.
 				dialog.addChoice(/.*/i, (msg) => {
-					res.reply(i18n.__('conversation.try.again.yes.no'));
+					robot.emit('ibmcloud.formatter', { response: res, message: i18n.__('conversation.try.again.yes.no')});
 					getResponse();
 				});
 			};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -66,205 +66,6 @@ describe('Test utility functions', function() {
 			expect(result).to.equal('1.0MB');
 		});
 
-
-		it('test expected response', function(done) {
-			let res = {
-				reply: function(msg) {}
-			};
-			let robot = {
-				name: 'hubot'
-			};
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'hubot Y';
-							let match = message.match(regex);
-							// only test expected response
-							if (String(regex) !== '/.*/i') {
-								func({match: match});
-							}
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = {};
-			let regex = /(Y)/i;
-
-			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex).then(() => {
-				done();
-			});
-		});
-
-		it('test expected unexpected response', function(done) {
-			let count = 0;
-			let res = {
-				reply: function(msg) {}
-			};
-			let robot = {
-				name: 'hubot'
-			};
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'hubot blah';
-							let match = message.match(regex);
-							if (match === null) {
-								return;
-							}
-							// unexpected response will cause the addChoice
-							// function to be called in an infinite loop
-							if (++count > 1) {
-								done();
-								return;
-							}
-							func({match: match});
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = {};
-			let regex = /(Y)/i;
-
-			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex);
-		});
-
-		it('test expected exit response', function(done) {
-			let res = {
-				reply: function(msg) {}
-			};
-			let robot = {
-				name: 'hubot'
-			};
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'exit';
-							let match = message.match(regex);
-							if (match === null) {
-								return;
-							}
-							func({match: match});
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = {};
-			let regex = /(Y)/i;
-
-			// catch rejected promise from 'exit' flow
-			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex)
-			.catch((err) => {
-				done();
-			});
-		});
-
-		it('test confirmed response `yes`', function(done) {
-			let res = {
-				reply: function(msg) {
-					return 'yes';
-				}
-			};
-
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'hubot yes';
-							let match = message.match(regex);
-							if (String(regex) === '/.*/i' || match === null) {
-								return;
-							}
-							func({match: match});
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = 'Test question (Yes or No)';
-			let negativeResponse = 'no';
-			utils.getConfirmedResponse(res, switchBoard, prompt, negativeResponse).then(() => {
-				done();
-			});
-		});
-
-		it('test confirmed response `no`', function(done) {
-			let res = {
-				reply: function(msg) {
-					return 'no';
-				}
-			};
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'hubot no';
-							let match = message.match(regex);
-							if (String(regex) === '/.*/i' || match === null) {
-								return;
-							}
-							func({match: match});
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = 'Test question (Yes or No)';
-			let negativeResponse = 'no';
-			utils.getConfirmedResponse(res, switchBoard, prompt, negativeResponse)
-			.catch((err) => {
-				done();
-			});
-		});
-
-		it('test confirmed response `unexpected response`', function(done) {
-			let count = 0;
-			let res = {
-				reply: function(msg) {
-					return 'blah';
-				}
-			};
-			let switchBoard = {
-				startDialog: function(res) {
-					let dialog = {
-						addChoice: function(regex, func) {
-							let message = 'hubot blah';
-							let match = message.match(regex);
-							if (match === null) {
-								return;
-							}
-							if (++count > 1) {
-								done();
-								return;
-							}
-							func({match: match});
-						},
-						resetChoices: function(){},
-						emit: function(){}
-					};
-					return dialog;
-				}
-			};
-			let prompt = 'Test question (Yes or No)';
-			let negativeResponse = 'no';
-			utils.getConfirmedResponse(res, switchBoard, prompt, negativeResponse);
-		});
-
 		it('test generated regex for numbered list of 7', function() {
 			let result = utils.generateRegExpForNumberedList(7);
 			expect('@hubot 5').to.match(result);
@@ -349,4 +150,177 @@ describe('Test utility functions', function() {
 		});
 	});
 
+	context('test conversation utils', function() {
+
+		let res;
+		let robot = {
+			name: 'hubot',
+			emit: function(target, message) {}
+		};
+
+		it('test expected response', function(done) {
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'hubot Y';
+							let match = message.match(regex);
+							// only test expected response
+							if (String(regex) !== '/.*/i') {
+								func({match: match});
+							}
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = {};
+			let regex = /(Y)/i;
+
+			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex).then(() => {
+				done();
+			});
+		});
+
+		it('test expected unexpected response', function(done) {
+			let count = 0;
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'hubot blah';
+							let match = message.match(regex);
+							if (match === null) {
+								return;
+							}
+							// unexpected response will cause the addChoice
+							// function to be called in an infinite loop
+							if (++count > 1) {
+								done();
+								return;
+							}
+							func({match: match});
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = {};
+			let regex = /(Y)/i;
+
+			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex);
+		});
+
+		it('test expected exit response', function(done) {
+			let res;
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'exit';
+							let match = message.match(regex);
+							if (match === null) {
+								return;
+							}
+							func({match: match});
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = {};
+			let regex = /(Y)/i;
+
+			// catch rejected promise from 'exit' flow
+			utils.getExpectedResponse(res, robot, switchBoard, prompt, regex)
+			.catch((err) => {
+				done();
+			});
+		});
+
+		it('test confirmed response `yes`', function(done) {
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'hubot yes';
+							let match = message.match(regex);
+							if (String(regex) === '/.*/i' || match === null) {
+								return;
+							}
+							func({match: match});
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = 'Test question (Yes or No)';
+			let negativeResponse = 'no';
+			utils.getConfirmedResponse(res, robot, switchBoard, prompt, negativeResponse).then(() => {
+				done();
+			});
+		});
+
+		it('test confirmed response `no`', function(done) {
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'hubot no';
+							let match = message.match(regex);
+							if (String(regex) === '/.*/i' || match === null) {
+								return;
+							}
+							func({match: match});
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = 'Test question (Yes or No)';
+			let negativeResponse = 'no';
+			utils.getConfirmedResponse(res, robot, switchBoard, prompt, negativeResponse)
+			.catch((err) => {
+				done();
+			});
+		});
+
+		it('test confirmed response `unexpected response`', function(done) {
+			let count = 0;
+			let switchBoard = {
+				startDialog: function(res) {
+					let dialog = {
+						addChoice: function(regex, func) {
+							let message = 'hubot blah';
+							let match = message.match(regex);
+							if (match === null) {
+								return;
+							}
+							if (++count > 1) {
+								done();
+								return;
+							}
+							func({match: match});
+						},
+						resetChoices: function(){},
+						emit: function(){}
+					};
+					return dialog;
+				}
+			};
+			let prompt = 'Test question (Yes or No)';
+			let negativeResponse = 'no';
+			utils.getConfirmedResponse(res, robot, switchBoard, prompt, negativeResponse);
+		});
+	});
 });


### PR DESCRIPTION
Tested changes with my bot and the `res.reply` to `robot.emit` switch did not affect the whole conversation aspect. 

The only thing I noticed is that the messages on **slack** seem to be out of order sometimes (they are in order when testing on shell). Not sure if this is a separate issue altogether with the slack portion of `hubot-ibmcloud-formatter`. I'm assuming that the messages _seemed_ to be _more_ in order before because of the `res.reply` behavior?

Anyways, the behavior is as expected. Changes that will have to be made across projects are:
- Include `robot` as second parameter for `getConfirmedResponse` method
- Ensure tests aren't super broken (i.e. `portend` tests will now be expecting more events emitted than before)

**Note:** As mentioned by @aeweidne in #24 , this should be included in a **major** release since it 100% affects multiple other repositories.

Including both @aeweidne and @CiaranHannigan in this PR since I spoke with both of you about the changes.
